### PR TITLE
Fixed the way that a document is requested from document api and stat…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,7 @@ module.exports = {
         'no-plusplus': 0,
         'arrow-body-style': 0,
         'react/destructuring-assignment': 0,
+        'react/prop-types': 0,
+        'react/jsx-one-expression-per-line': 0,
     }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,37 @@ import './App.css';
 import Workflow from './components/Workflow/Workflow';
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: '',
+      submitted: false,
+    };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleChange(event) {
+    this.setState({ submitted: false });
+    this.setState({ value: event.target.value });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this.setState({ submitted: true });
+  }
+
   render() {
+    const workflow = this.state.submitted ? <Workflow doc_id={this.state.value} /> : '';
     return (
       <div className="App">
-        <Workflow />
+        <form onSubmit={this.handleSubmit}>
+          Document id:
+          <input type="text" value={this.state.value} onChange={this.handleChange} />
+          <input type="submit" value="Submit" />
+        </form>
+        <br />
+        { workflow }
       </div>
     );
   }

--- a/src/components/Workflow/Workflow.jsx
+++ b/src/components/Workflow/Workflow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import WorkflowUtils from './WorkflowUtils';
 import api from '../../api/api';
 
 class Workflow extends React.Component {
@@ -10,17 +11,20 @@ class Workflow extends React.Component {
   }
 
   componentDidMount() {
-    api.getDocumentStates(14)
+    api.getDocumentStates(this.props.doc_id)
       .then((response) => {
-        this.setState({ states: response });
+        const states_list = WorkflowUtils.getStatelist(response);
+        this.setState({ states: states_list });
       });
   }
 
   render() {
-    const lel = JSON.stringify(this.state.states);
     return (
       <div>
-        { lel }
+        Estados del documento con id {this.props.doc_id}:
+        <br />
+        <br />
+        { this.state.states }
       </div>
     );
   }

--- a/src/components/Workflow/WorkflowUtils.js
+++ b/src/components/Workflow/WorkflowUtils.js
@@ -1,8 +1,0 @@
-const getStatelist = (documentStates) => {
-  // TODO: Extraer los estados desde el JSON
-  return documentStates;
-};
-
-export default {
-  getStatelist,
-};

--- a/src/components/Workflow/WorkflowUtils.jsx
+++ b/src/components/Workflow/WorkflowUtils.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const getStatelist = (documentStates) => {
+  return documentStates.map(state => <li>{state.fields.state_name.toString()}</li>);
+};
+
+export default {
+  getStatelist,
+};


### PR DESCRIPTION
## Problema

La obtención de los estados de un documento estaba completamente hardcodeado y solo permitía la visualización de un solo documento.

## Solución

Se colocó un form que recibe un número correspondiente a la id de un documento. Al hacer submit este documento se busca en la base de datos de la api y retorna los estados del documento solicitados, mostrándolos en el navegador como una lista

## Como probar

Tener el backend corriendo el localhost:8000 y correr el frontend con 
```
yarn start
```

Posteriormente ingresar una id en el form.