### PR TITLE
Fixes incorrect get parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
     "jest-dom": "^3.0.0",
+    "jquery": "^3.3.1",
     "react": "^16.7.0",
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.7.0",

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,6 @@ class App extends Component {
     return (
       <div className="App">
         <Document1 />
-        <Workflow />
         <form onSubmit={this.handleSubmit}>
           Document id:
           <input type="text" value={this.state.value} onChange={this.handleChange} />

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import $ from 'jquery';
 
 const API_HOST = 'http://127.0.0.1:8000/dp';
 const API_TESTS = 'http://127.0.0.1:8000/test';
@@ -15,10 +16,7 @@ function getDocumentsTypes() {
 }
 
 function getDocumentStates(document_id) {
-  return axios.get(`${API_HOST}/get_document_states`, {
-    params: {
-      doc_id: document_id,
-    },
+  return axios.get(`${API_HOST}/get_document_states?doc_id=${document_id}`, {
   })
     .then((response) => {
       return response.data;
@@ -29,10 +27,7 @@ function getDocumentStates(document_id) {
 }
 
 function getDocumentTransitions(document_id) {
-  return axios.get(`${API_HOST}/get_document_transitions`, {
-    params: {
-      doc_id: document_id,
-    },
+  return axios.get(`${API_HOST}/get_document_transitions?doc_id=${document_id}`, {
   })
     .then((response) => {
       return response.data;
@@ -43,10 +38,7 @@ function getDocumentTransitions(document_id) {
 }
 
 function getDocumetSections(document_id) {
-  return axios.get(`${API_HOST}/get_document_sections`, {
-    params: {
-      doc_id: document_id,
-    },
+  return axios.get(`${API_HOST}/get_document_sections?doc_id=${document_id}`, {
   })
     .then((response) => {
       return response.data;
@@ -95,6 +87,26 @@ function getDocument1(document_id) {
     });
 }
 
+function getFormData($form) {
+  const unindexed_array = $form.serializeArray();
+  const indexed_array = {};
+
+  $.map(unindexed_array, (n) => {
+    indexed_array[n.name] = n.value;
+  });
+
+  return indexed_array;
+}
+
+function postDocument1Url(document_id, form) {
+  return axios.post(`${API_TESTS}/save_document1/${document_id}/`,
+    getFormData(form)).then((response) => {
+    return response.data;
+  }).catch((err) => {
+    console.log(err);
+  });
+}
+
 export default {
   getDocumentStates,
   getDocumentsTypes,
@@ -103,4 +115,5 @@ export default {
   getPreviousDocumentStates,
   getNextDocumentStates,
   getDocument1,
+  postDocument1Url,
 };

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -11,7 +11,7 @@ function getDocumentsTypes() {
       return response;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -22,7 +22,7 @@ function getDocumentStates(document_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -33,7 +33,7 @@ function getDocumentTransitions(document_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -44,7 +44,7 @@ function getDocumetSections(document_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -58,7 +58,7 @@ function getPreviousDocumentStates(s_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -72,7 +72,7 @@ function getNextDocumentStates(s_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -83,7 +83,7 @@ function getDocument1(document_id) {
       return response.data;
     })
     .catch((err) => {
-      console.log(err);
+      alert(err);
     });
 }
 
@@ -103,7 +103,7 @@ function postDocument1Url(document_id, form) {
     getFormData(form)).then((response) => {
     return response.data;
   }).catch((err) => {
-    console.log(err);
+    alert(err);
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,6 +5796,11 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
+jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
# Problema
Al hacer requests para obtener los estados o transiciones de un documento no se incluían los parámetros necesarios y el servidor retornaba un error.

# Solución
Modificar las funciones de api.js que se encargaban de estas request y agregar los parametros necesarios a las url.

# Test
Hacer un request get a `get_document_states` o a `get_document_transitions` con el parametro `doc_id`con un valor valido y ver que el servidor responda con codigo 200.

_*Un parametro valido es cualquier id de la tabla ContentType correspondiente al modelo de un documento._ 