### PR TITLE
Added visualization to doc state and buttons for possible transitions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,39 +4,11 @@ import Workflow from './components/Workflow/Workflow';
 import Document1 from './components/Documents/Document1Edit';
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: '',
-      submitted: false,
-    };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  handleChange(event) {
-    this.setState({ submitted: false });
-    this.setState({ value: event.target.value });
-  }
-
-  handleSubmit(event) {
-    event.preventDefault();
-    this.setState({ submitted: true });
-  }
-
   render() {
-    const workflow = this.state.submitted ? <Workflow doc_id={this.state.value} /> : '';
     return (
       <div className="App">
         <Document1 />
-        <Workflow />
-        <form onSubmit={this.handleSubmit}>
-          Document id:
-          <input type="text" value={this.state.value} onChange={this.handleChange} />
-          <input type="submit" value="Submit" />
-        </form>
-        <br />
-        { workflow }
+        <Workflow doc_id={14} />
       </div>
     );
   }

--- a/src/__tests__/workflow.test.js
+++ b/src/__tests__/workflow.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from 'react-testing-library';
+import 'jest-dom/extend-expect';
+import Workflow from '../components/Workflow/Workflow';
+
+test('Workflow sections rendering', () => {
+  const { getByText } = render(
+    <Workflow />,
+  );
+  expect.anything(getByText('Estado del documento'));
+  expect.anything(getByText('Estado actual del documento:'));
+  expect.anything(getByText('Transiciones aplicables:'));
+});

--- a/src/components/Workflow/Workflow.jsx
+++ b/src/components/Workflow/Workflow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Jumbotron, Badge, ButtonGroup } from 'reactstrap';
+import { Jumbotron, Badge, ButtonGroup, Button } from 'reactstrap';
 import WorkflowUtils from './WorkflowUtils';
 import api from '../../api/api';
 import './Workflow.css';
@@ -16,7 +16,9 @@ class Workflow extends React.Component {
       document: [],
       currentState: '',
       possibleTransitions: '',
+      rSelected: '',
     };
+    this.onRadioBtnClick = this.onRadioBtnClick.bind(this);
   }
 
   componentDidMount() {
@@ -40,9 +42,16 @@ class Workflow extends React.Component {
     if (this.state.states.length > 0 && this.state.transitions.length > 0 && this.state.document.length > 0) {
       if (this.state.currentState === '') {
         this.setState({ currentState: WorkflowUtils.getCurrentState(this) });
-        this.setState({ possibleTransitions: WorkflowUtils.getPossibleTransitions(this) });
+        this.setState({
+          possibleTransitions: WorkflowUtils.getPossibleTransitions(this)
+            .map(transition => <Button color="primary" onClick={() => this.onRadioBtnClick(transition[0])} active={this.state.rSelected === transition[0]}>{transition[1].toString()}</Button>)
+        });
       }
     }
+  }
+
+  onRadioBtnClick(rSelected) {
+    this.setState({ rSelected });
   }
 
   render() {

--- a/src/components/Workflow/Workflow.jsx
+++ b/src/components/Workflow/Workflow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Jumbotron, Badge, ButtonGroup } from 'reactstrap';
 import WorkflowUtils from './WorkflowUtils';
 import api from '../../api/api';
 import './Workflow.css';
@@ -7,41 +8,61 @@ import './Workflow.css';
 class Workflow extends React.Component {
   constructor() {
     super();
+    this.states = [];
+    this.transitions = [];
     this.state = {
       states: [],
       transitions: [],
+      document: [],
+      currentState: '',
+      possibleTransitions: '',
     };
   }
 
   componentDidMount() {
     api.getDocumentStates(this.props.doc_id)
       .then((response) => {
-        const states_list = WorkflowUtils.getStatelist(response);
-        this.setState({ states: states_list });
+        this.setState({ states: JSON.stringify(response) });
+        this.transitions = JSON.stringify(response);
       });
     api.getDocumentTransitions(this.props.doc_id)
       .then((response) => {
-        const transitions_list = WorkflowUtils.getTransitionList(response);
-        this.setState({ transitions: transitions_list });
+        this.setState({ transitions: JSON.stringify(response) });
+        this.states = JSON.stringify(response);
       });
+    api.getDocument1(1)
+      .then((response) => {
+        this.setState({ document: JSON.stringify(response) });
+      });
+  }
+
+  componentDidUpdate() {
+    if (this.state.states.length > 0 && this.state.transitions.length > 0 && this.state.document.length > 0) {
+      if (this.state.currentState === '') {
+        this.setState({ currentState: WorkflowUtils.getCurrentState(this) });
+        this.setState({ possibleTransitions: WorkflowUtils.getPossibleTransitions(this) });
+      }
+    }
   }
 
   render() {
     return (
-      <div>
-        Estados del documento {this.props.doc_id}:
-        <br />
-        <br />
-        <div className="Workflow-States-Container">
-          { this.state.states }
+      <Jumbotron>
+        <div>
+        <h3 className="text-left">
+          Estado del documento
+        </h3>
+          <br />
+          <h5 className="text-left"> Estado actual del documento: &nbsp;&nbsp;&nbsp;<Badge color="secondary">{this.state.currentState}</Badge></h5>
+          <br />
+          <br />
+          <h5 className="text-left"> Transiciones aplicables:</h5>
+          <br />
+          <ButtonGroup>
+            {this.state.possibleTransitions}
+          </ButtonGroup>
         </div>
-        <br />
-        <br />
-        Transiciones del documento:
-        <br />
-        <br />
-        { this.state.transitions }
-      </div>
+      </Jumbotron>
     );
   }
 }

--- a/src/components/Workflow/WorkflowUtils.jsx
+++ b/src/components/Workflow/WorkflowUtils.jsx
@@ -23,7 +23,7 @@ const getPossibleTransitions = (workflow) => {
   const transitionsJSON = JSON.parse(workflow.state.transitions);
   const id = docJSON.state;
   const possibleTransitions = transitionsJSON.filter(e => e.fields.start_state === id);
-  return possibleTransitions.map(transition => <Button color="primary">{transition.fields.name.toString()}</Button>);
+  return possibleTransitions.map(transition => [transition.pk, transition.fields.name]);
 };
 
 export default {

--- a/src/components/Workflow/WorkflowUtils.jsx
+++ b/src/components/Workflow/WorkflowUtils.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Button } from 'reactstrap';
+
 
 const getStatelist = (documentStates) => {
   return documentStates.map(state => <div>{state.fields.state_name.toString()}</div>);
@@ -8,7 +10,25 @@ const getTransitionList = (documentTransitions) => {
   return documentTransitions.map(transition => <div>{transition.fields.name.toString()}</div>);
 };
 
+const getCurrentState = (workflow) => {
+  const docJSON = JSON.parse(workflow.state.document);
+  const statesJSON = JSON.parse(workflow.state.states);
+  const id = docJSON.state;
+  const currentState = statesJSON.find(e => e.pk === id);
+  return currentState.fields.state_name.toString();
+};
+
+const getPossibleTransitions = (workflow) => {
+  const docJSON = JSON.parse(workflow.state.document);
+  const transitionsJSON = JSON.parse(workflow.state.transitions);
+  const id = docJSON.state;
+  const possibleTransitions = transitionsJSON.filter(e => e.fields.start_state === id);
+  return possibleTransitions.map(transition => <Button color="primary">{transition.fields.name.toString()}</Button>);
+};
+
 export default {
   getStatelist,
   getTransitionList,
+  getCurrentState,
+  getPossibleTransitions,
 };


### PR DESCRIPTION
## Problema

No existe una manera de visualizar el estado actual de un documento ni las transiciones posibles desde este.

## Solución

Se añade una integración con bootstrap que permite mostrar el estado actual y botones para las transiciones

## Como probar

Correr el backend en localhost:8000 y el front con 
```
yarn start
```