### PR TITLE
Added functionality to save the historic transitions of a document

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -100,7 +100,12 @@ function getFormData($form) {
 
 function postDocument1Url(document_id, form) {
   return axios.post(`${API_TESTS}/save_document1/${document_id}/`,
-    getFormData(form)).then((response) => {
+    getFormData(form), {
+      auth: {
+        username: 'luis.bustos',
+        password: '1234',
+      },
+    }).then((response) => {
     return response.data;
   }).catch((err) => {
     alert(err);

--- a/src/components/Documents/Document1Edit.jsx
+++ b/src/components/Documents/Document1Edit.jsx
@@ -18,11 +18,13 @@ class Document1 extends React.Component {
       end_date: '',
       description: '',
       doc_state: '',
-     };
+      nextTransitionId: '',
+    };
 
-     this.formRef = React.createRef();
-     this._handleSubmit = this._handleSubmit.bind(this);
-     this.setNextState = this.setNextState.bind(this)
+    this.formRef = React.createRef();
+    this._handleSubmit = this._handleSubmit.bind(this);
+    this.setNextState = this.setNextState.bind(this);
+    this.setTransition = this.setTransition.bind(this);
   }
 
   componentDidMount() {
@@ -56,8 +58,9 @@ class Document1 extends React.Component {
           <WorkSection start_date={this.state.start_date}
                        end_date={this.state.end_date}
                        description={this.state.description}/>
-          <Workflow doc_id={14} set_state_cb={this.setNextState}/>
+          <Workflow doc_id={14} set_state_cb={this.setNextState} set_transition_cb={this.setTransition}/>
           <input type="hidden" name="state" value={this.state.doc_state}/>
+          <input type="hidden" name="transition" value={this.state.nextTransitionId}/>
           <input type="submit" value="Submit" />
           </form>
         </div>
@@ -71,29 +74,19 @@ class Document1 extends React.Component {
     window.location.reload();
   }
 
+  setTransition(transition_id) {
+    this.setState({
+      nextTransitionId: transition_id,
+    });
+  }
+
   setNextState(next_state) {
     this.setState({
       doc_state: next_state,
     });
   }
 
-  _handleSubmit(e){
-    e.preventDefault();
-    api.postDocument1Url(1, $("#docForm"));
-    window.location.reload();
-  }
 
-  setNextState(next_state) {
-    this.setState({
-      doc_state: next_state,
-    });
-  }
-
-  _handleSubmit(e){
-    e.preventDefault();
-    api.postDocument1Url(1, $("#docForm"));
-    window.location.reload();
-  }
 }
 
 export default Document1;

--- a/src/components/Workflow/Workflow.jsx
+++ b/src/components/Workflow/Workflow.jsx
@@ -21,6 +21,7 @@ class Workflow extends React.Component {
       comment: '',
     };
     this.onRadioBtnClick = this.onRadioBtnClick.bind(this);
+    this.onChangeFunction = this.onChangeFunction.bind(this);
   }
 
   componentDidMount() {
@@ -46,16 +47,18 @@ class Workflow extends React.Component {
         this.setState({ currentState: WorkflowUtils.getCurrentState(this) });
         this.setState({
           possibleTransitions: WorkflowUtils.getPossibleTransitions(this)
-            .map(transition => <Button color="primary" onClick={() => this.onRadioBtnClick(transition[0])} active={this.state.rSelected === transition[0]}>{transition[1].toString()}</Button>)
+            .map(transition => <Button color="primary" onClick={() => this.onRadioBtnClick(transition[0])} active={this.state.rSelected === transition[0]}>{transition[1].toString()}</Button>),
+          comment: '',
         });
       }
     }
   }
 
   onRadioBtnClick(rSelected) {
-    this.setState({ rSelected });
-    this.props.set_state_cb(rSelected)
-    this.addCommentTextArea(rSelected);
+    this.setState({ rSelected: rSelected[0] });
+    this.props.set_state_cb(rSelected[0]);
+    this.props.set_transition_cb(rSelected[1]);
+    this.addCommentTextArea(rSelected[1]);
   }
 
   onChangeFunction(component, value) {

--- a/src/components/Workflow/WorkflowUtils.jsx
+++ b/src/components/Workflow/WorkflowUtils.jsx
@@ -21,7 +21,7 @@ const getPossibleTransitions = (workflow) => {
   const transitionsJSON = JSON.parse(workflow.state.transitions);
   const id = docJSON.state;
   const possibleTransitions = transitionsJSON.filter(e => e.fields.start_state === id);
-  return possibleTransitions.map(transition => [transition.fields.end_state, transition.fields.name]);
+  return possibleTransitions.map(transition => [[transition.fields.end_state, transition.pk], transition.fields.name]);
 };
 
 export default {


### PR DESCRIPTION
## Problema

No existe una manera de que el backend sepa que tiene que guardar el historial de transiciones de un documento

## Solución

Se envían los campos de los comentarios y la id de la transición para que el backend pueda grardar el historial

## Como probar 

Correr el backend en localhost:8000 y el frontend con 
```
yarn start
```

Después hay que aplicar una transición cualquiera al documento y se guardará en el backend